### PR TITLE
fix(sec): upgrade @fastify/websocket to 7.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@commercial/subtext": "^5.1.1",
-        "@fastify/websocket": "5.0.0",
+        "@fastify/websocket": "7.1.1",
         "@uppy/companion": "~2.0.0-alpha.0",
         "@xmldom/xmldom": "*0.8.0"
       },
@@ -2339,11 +2339,11 @@
       }
     },
     "node_modules/@fastify/websocket": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmmirror.com/@fastify/websocket/-/websocket-5.0.0.tgz",
-      "integrity": "sha512-ngZo5rchmhRZaML4MkAY/ClGs8Iyp0+rL97EIP0QsU2N4ICqBKEBG/wGL21ImAhha1RFixEzz8+CB/Ad/W50yw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmmirror.com/@fastify/websocket/-/websocket-7.1.1.tgz",
+      "integrity": "sha512-8lvB/E6p/o3MlmHzM2NJ19ixteI6Ckw0xOebLfoHoORPmpvCWqSp8+HLz4Gc6HrChH4vM9VcSWAK8jYuTT08hQ==",
       "dependencies": {
-        "fastify-plugin": "^3.0.0",
+        "fastify-plugin": "^4.0.0",
         "ws": "^8.0.0"
       }
     },
@@ -5819,9 +5819,9 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fastify-plugin": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmmirror.com/fastify-plugin/-/fastify-plugin-3.0.1.tgz",
-      "integrity": "sha512-qKcDXmuZadJqdTm6vlCqioEbyewF60b/0LOFCcYN1B6BIZGlYJumWWOYs70SFYLDAH4YqdE1cxH/RKMG7rFxgA=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/fastify-plugin/-/fastify-plugin-4.3.0.tgz",
+      "integrity": "sha512-M3+i368lV0OYTJ5TfClIoPKEKSOF7112iiPdwgfSR0gN98BjA1Nk+c6oBHtfcVt9KiMxl+EQKHC1QNWo3ZOpYQ=="
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -14416,11 +14416,11 @@
       "optional": true
     },
     "@fastify/websocket": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmmirror.com/@fastify/websocket/-/websocket-5.0.0.tgz",
-      "integrity": "sha512-ngZo5rchmhRZaML4MkAY/ClGs8Iyp0+rL97EIP0QsU2N4ICqBKEBG/wGL21ImAhha1RFixEzz8+CB/Ad/W50yw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmmirror.com/@fastify/websocket/-/websocket-7.1.1.tgz",
+      "integrity": "sha512-8lvB/E6p/o3MlmHzM2NJ19ixteI6Ckw0xOebLfoHoORPmpvCWqSp8+HLz4Gc6HrChH4vM9VcSWAK8jYuTT08hQ==",
       "requires": {
-        "fastify-plugin": "^3.0.0",
+        "fastify-plugin": "^4.0.0",
         "ws": "^8.0.0"
       }
     },
@@ -17181,9 +17181,9 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fastify-plugin": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmmirror.com/fastify-plugin/-/fastify-plugin-3.0.1.tgz",
-      "integrity": "sha512-qKcDXmuZadJqdTm6vlCqioEbyewF60b/0LOFCcYN1B6BIZGlYJumWWOYs70SFYLDAH4YqdE1cxH/RKMG7rFxgA=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/fastify-plugin/-/fastify-plugin-4.3.0.tgz",
+      "integrity": "sha512-M3+i368lV0OYTJ5TfClIoPKEKSOF7112iiPdwgfSR0gN98BjA1Nk+c6oBHtfcVt9KiMxl+EQKHC1QNWo3ZOpYQ=="
     },
     "fastq": {
       "version": "1.13.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@uppy/companion": "~2.0.0-alpha.0",
     "@commercial/subtext": "^5.1.1",
     "@xmldom/xmldom": "*0.8.0",
-    "@fastify/websocket": "5.0.0"
+    "@fastify/websocket": "7.1.1"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^14.2.8",


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in @fastify/websocket 5.0.0
- [CVE-2022-39386](https://www.oscs1024.com/hd/CVE-2022-39386)


### What did I do？
Upgrade @fastify/websocket from 5.0.0 to 7.1.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS